### PR TITLE
Create output file only if file_output is set in config

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ var logger_file_writer = null;
 
 if (file_output) {
   logger_file_writer = getFileWriter();
-  logger = new console.Console(logger_file_writer,logger_file_writer);
+  logger = new console.Console(logger_file_writer, logger_file_writer);
 
   const logger_options = {
     pattern: "dd-mm HH:MM:ss",
@@ -24,7 +24,7 @@ if (file_output) {
     stdout: logger_file_writer
   };
 
-  console_stamp(logger,logger_options);
+  console_stamp(logger, logger_options);
 }
 
 if (!graph_only) {
@@ -33,7 +33,7 @@ if (!graph_only) {
     label: false
   };
 
-  console_stamp(console,console_stamp_options);
+  console_stamp(console, console_stamp_options);
 }
 
 const spacesNum = config.get('space_width');


### PR DESCRIPTION
First of all big thanks for this code! It's been very useful to easily identify leaked pipelines in a project I'm working on. :)

About this PR: I noticed that when the `file_output` option is set to 0 in the config the .out file is still created - not populated, but created - which can lead to have many undesired empty .out files pretty quickly. I've added a small change to only generate the file if the `file_output` value is set to 1.